### PR TITLE
jj - BACKEND - Add delete for roster student

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -115,7 +115,6 @@ public class RosterStudentsController extends ApiController {
     @Operation(summary = "Delete a roster student")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @DeleteMapping("")
-    // @Transactional
     public Object deleteRosterStudent(
             @Parameter(name="id") @RequestParam Long id) {
         RosterStudent rosterStudent = rosterStudentRepository.findById(id)

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -106,6 +106,26 @@ public class RosterStudentsController extends ApiController {
     }
 
     /**
+     * This method deletes an existing RosterStudent.
+     * 
+     * @param id the id of the roster student to delete
+     * @return a message indicating the RosterStudent was deleted
+     */
+
+    @Operation(summary = "Delete a roster student")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    // @Transactional
+    public Object deleteRosterStudent(
+            @Parameter(name="id") @RequestParam Long id) {
+        RosterStudent rosterStudent = rosterStudentRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(RosterStudent.class, id));
+
+        rosterStudentRepository.delete(rosterStudent);
+        return genericMessage("RosterStudent with id %s deleted".formatted(id));
+    }
+
+    /**
      * This method returns a list of roster students for a given course.
      * 
      * @return a list of all courses.

--- a/src/main/java/edu/ucsb/cs156/frontiers/entities/Course.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/entities/Course.java
@@ -41,7 +41,7 @@ public class Course {
     @ToString.Exclude
     private List<CourseStaff> courseStaff;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "course")
+    @OneToMany(cascade = CascadeType.REMOVE, mappedBy = "course", orphanRemoval = true)
     @Fetch(FetchMode.JOIN)
     @JsonIgnore
     @ToString.Exclude


### PR DESCRIPTION
Closes #25 

In this PR, I created a DELETE endpoint for RosterStudents to be able to remove existing RosterStudents by id.
The code can be tested on localhost and dokku.
1. Log in to dokku or localhost
2. Go to Swagger and the Courses section
3. Create a new Course
4. Go to the RosterStudent section and create a new RosterStudent with the course id of the course you created
5. Test the delete endpoint by deleting the RosterStudent you created

The dokku deployment can be accessed here: https://frontiers-tizerk-dev.dokku-12.cs.ucsb.edu/

<img width="678" alt="image" src="https://github.com/user-attachments/assets/f2665a32-0ed4-42b2-abfe-d52078fc7eef" />
