### PR TITLE
mw - Add Fixtures for RosterStudents

### DIFF
--- a/frontend/src/fixtures/rosterStudentsFixtures.js
+++ b/frontend/src/fixtures/rosterStudentsFixtures.js
@@ -1,0 +1,49 @@
+import coursesFixtures from "./coursesFixtures";
+import usersFixtures from "./usersFixtures";
+
+const rosterStudentsFixtures = {
+  // three roster students from the same course.
+  threeRosterStudents: [
+    {
+      id: 1,
+      course: coursesFixtures.threeCourses[0],
+      studentID: "1234X67",
+      firstName: "Phill",
+      lastName: "Conrad",
+      email: "phtcon@ucsb.edu",
+      user: usersFixtures.threeUsers[0],
+      rosterStatus: "MANUAL",
+      orgStatus: "NONE",
+      githubId: null,
+      githubLogin: null,
+    },
+    {
+      id: 2,
+      course: coursesFixtures.threeCourses[0],
+      studentID: "XM43KJ3",
+      firstName: "Phillip",
+      lastName: "Conrad",
+      email: "pconrad.cis@gmail.com",
+      user: usersFixtures.threeUsers[1],
+      rosterStatus: "ROSTER",
+      orgStatus: "MEMBER",
+      githubId: 123456789,
+      githubLogin: "pconrad",
+    },
+    {
+      id: 3,
+      course: coursesFixtures.threeCourses[0],
+      studentID: "ZZZZZZZ",
+      firstName: "Craig",
+      lastName: "Zzyxx",
+      email: "craig.zzyzx@example.org",
+      user: usersFixtures.threeUsers[2],
+      rosterStatus: "DROPPED",
+      orgStatus: "NONE",
+      githubId: null,
+      githubLogin: null,
+    },
+  ],
+};
+
+export default rosterStudentsFixtures;

--- a/frontend/src/fixtures/rosterStudentsFixtures.js
+++ b/frontend/src/fixtures/rosterStudentsFixtures.js
@@ -7,7 +7,7 @@ const rosterStudentsFixtures = {
     {
       id: 1,
       course: coursesFixtures.threeCourses[0],
-      studentID: "1234X67",
+      studentId: "1234X67",
       firstName: "Phill",
       lastName: "Conrad",
       email: "phtcon@ucsb.edu",
@@ -20,7 +20,7 @@ const rosterStudentsFixtures = {
     {
       id: 2,
       course: coursesFixtures.threeCourses[0],
-      studentID: "XM43KJ3",
+      studentId: "XM43KJ3",
       firstName: "Phillip",
       lastName: "Conrad",
       email: "pconrad.cis@gmail.com",
@@ -33,7 +33,7 @@ const rosterStudentsFixtures = {
     {
       id: 3,
       course: coursesFixtures.threeCourses[0],
-      studentID: "ZZZZZZZ",
+      studentId: "ZZZZZZZ",
       firstName: "Craig",
       lastName: "Zzyxx",
       email: "craig.zzyzx@example.org",


### PR DESCRIPTION
Closes #31 

This PR adds Fixtures for Roster students, in `frontend/src/fixtures/rosterStudentsFixtures.js`. These fixtures will be used in Storybook stories for components related to Roster student CRUD.

No screenshots/dokku deployment, as there are no visual changes to the app/storybook.