### PR TITLE
mw - Add table component for RosterStudents plus stories and tests

### DIFF
--- a/frontend/src/main/components/RosterStudents/RosterStudentsTable.js
+++ b/frontend/src/main/components/RosterStudents/RosterStudentsTable.js
@@ -8,6 +8,10 @@ const columns = [
     accessor: "id", // accessor is the "key" in the data
   },
   {
+    Header: "Student ID",
+    accessor: "studentId",
+  },
+  {
     Header: "First Name",
     accessor: "firstName",
   },

--- a/frontend/src/main/components/RosterStudents/RosterStudentsTable.js
+++ b/frontend/src/main/components/RosterStudents/RosterStudentsTable.js
@@ -1,0 +1,95 @@
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+const columns = [
+  {
+    Header: "id",
+    accessor: "id", // accessor is the "key" in the data
+  },
+  {
+    Header: "First Name",
+    accessor: "firstName",
+  },
+  {
+    Header: "Last Name",
+    accessor: "lastName",
+  },
+  {
+    Header: "Email",
+    accessor: "email",
+  },
+  {
+    Header: "Roster Status",
+    accessor: "rosterStatus",
+  },
+  {
+    Header: "Github Org Status",
+    accessor: "orgStatus",
+  },
+  {
+    Header: "Github ID",
+    accessor: "githubId",
+  },
+  {
+    Header: "Github Username",
+    accessor: "githubLogin",
+  },
+];
+
+export default function RosterStudentsTable({
+  rosterStudents,
+  showButtons = false,
+  storybook = false,
+}) {
+  const editCallback = (cell) => {
+    const url = `/api/rosterstudents/edit/${cell.row.values.id}`;
+    if (storybook) {
+      window.alert(`would have navigated to: ${url}`);
+      return;
+    }
+    window.location.href = url;
+  };
+
+  // Stryker disable all : hard to test for query caching
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/rosterstudents/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const buttonColumns = [
+    ...columns,
+    ButtonColumn("Edit", "primary", editCallback, "RosterStudentsTable"),
+    ButtonColumn("Delete", "danger", deleteCallback, "RosterStudentsTable"),
+  ];
+
+  return (
+    <OurTable
+      data={rosterStudents}
+      columns={showButtons ? buttonColumns : columns}
+      testid={"RosterStudentsTable"}
+    />
+  );
+}
+
+function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/rosterstudents",
+    method: "DELETE",
+    params: {
+      id: cell.row.values.id,
+    },
+  };
+}

--- a/frontend/src/main/components/RosterStudents/RosterStudentsTable.js
+++ b/frontend/src/main/components/RosterStudents/RosterStudentsTable.js
@@ -1,6 +1,11 @@
 import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
-import { toast } from "react-toastify";
+import { useNavigate } from "react-router-dom";
+
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/rosterStudentUtils";
 
 const columns = [
   {
@@ -44,15 +49,11 @@ const columns = [
 export default function RosterStudentsTable({
   rosterStudents,
   showButtons = false,
-  storybook = false,
 }) {
+  const navigate = useNavigate();
+
   const editCallback = (cell) => {
-    const url = `/api/rosterstudents/edit/${cell.row.values.id}`;
-    if (storybook) {
-      window.alert(`would have navigated to: ${url}`);
-      return;
-    }
-    window.location.href = url;
+    navigate(`/rosterstudents/edit/${cell.row.values.id}`);
   };
 
   // Stryker disable all : hard to test for query caching
@@ -81,19 +82,4 @@ export default function RosterStudentsTable({
       testid={"RosterStudentsTable"}
     />
   );
-}
-
-function onDeleteSuccess(message) {
-  console.log(message);
-  toast(message);
-}
-
-function cellToAxiosParamsDelete(cell) {
-  return {
-    url: "/api/rosterstudents",
-    method: "DELETE",
-    params: {
-      id: cell.row.values.id,
-    },
-  };
 }

--- a/frontend/src/main/utils/rosterStudentUtils.js
+++ b/frontend/src/main/utils/rosterStudentUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/rosterstudents",
+    method: "DELETE",
+    params: {
+      id: cell.row.values.id,
+    },
+  };
+}

--- a/frontend/src/stories/components/RosterStudents/RosterStudentsTable.stories.js
+++ b/frontend/src/stories/components/RosterStudents/RosterStudentsTable.stories.js
@@ -1,0 +1,35 @@
+import React from "react";
+
+import RosterStudentsTable from "main/components/RosterStudents/RosterStudentsTable";
+import rosterStudentsFixtures from "fixtures/rosterStudentsFixtures";
+
+export default {
+  title: "components/RosterStudents/RosterStudentsTable",
+  component: RosterStudentsTable,
+};
+
+const Template = (args) => {
+  return <RosterStudentsTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+export const ThreeRosterStudents = Template.bind({});
+export const ThreeRosterStudentsWithButtons = Template.bind({});
+
+Empty.args = {
+  rosterStudents: [],
+};
+Empty.parameters = {};
+
+ThreeRosterStudents.args = {
+  rosterStudents: rosterStudentsFixtures.threeRosterStudents,
+};
+ThreeRosterStudents.parameters = {};
+
+// This story is for testing the Edit/Delete buttons
+ThreeRosterStudentsWithButtons.args = {
+  rosterStudents: rosterStudentsFixtures.threeRosterStudents,
+  showButtons: true,
+  storybook: true,
+};
+ThreeRosterStudentsWithButtons.parameters = {};

--- a/frontend/src/tests/components/RosterStudents/RosterStudentsTable.test.js
+++ b/frontend/src/tests/components/RosterStudents/RosterStudentsTable.test.js
@@ -1,0 +1,173 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import rosterStudentsFixtures from "fixtures/rosterStudentsFixtures";
+import RosterStudentsTable from "main/components/RosterStudents/RosterStudentsTable";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe("RosterStudentsTable tests", () => {
+  const queryClient = new QueryClient();
+
+  test("Has the expected column headers and content", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RosterStudentsTable
+            rosterStudents={rosterStudentsFixtures.threeRosterStudents}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const expectedHeaders = [
+      "id",
+      "Student ID",
+      "First Name",
+      "Last Name",
+      "Email",
+      "Roster Status",
+      "Github Org Status",
+      "Github ID",
+      "Github Username",
+    ];
+    const expectedFields = [
+      "id",
+      "studentId",
+      "firstName",
+      "lastName",
+      "email",
+      "rosterStatus",
+      "orgStatus",
+      "githubId",
+      "githubLogin",
+    ];
+    const testId = "RosterStudentsTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-studentId`),
+    ).toHaveTextContent("1234X67");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-firstName`),
+    ).toHaveTextContent("Phill");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-lastName`),
+    ).toHaveTextContent("Conrad");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-email`),
+    ).toHaveTextContent("phtcon@ucsb.edu");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-rosterStatus`),
+    ).toHaveTextContent("MANUAL");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-orgStatus`),
+    ).toHaveTextContent("NONE");
+    // github ID and Login are empty when null
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-githubId`),
+    ).toHaveTextContent("");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-githubLogin`),
+    ).toHaveTextContent("");
+  });
+
+  test("Does NOT show buttons by default", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RosterStudentsTable
+            rosterStudents={rosterStudentsFixtures.threeRosterStudents}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const editButton = screen.queryByTestId(
+      "RosterStudentsTable-cell-row-0-col-Edit-button",
+    );
+    expect(editButton).not.toBeInTheDocument();
+
+    const deleteButton = screen.queryByTestId(
+      "RosterStudentsTable-cell-row-0-col-Delete-button",
+    );
+    expect(deleteButton).not.toBeInTheDocument();
+  });
+
+  test("Edit button appears and navigates to edit page", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RosterStudentsTable
+            rosterStudents={rosterStudentsFixtures.threeRosterStudents}
+            showButtons={true}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const editButton = screen.getByTestId(
+      "RosterStudentsTable-cell-row-0-col-Edit-button",
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveTextContent("Edit");
+    expect(editButton).toHaveAttribute("class", "btn btn-primary");
+
+    fireEvent.click(editButton);
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith("/rosterstudents/edit/1"),
+    );
+  });
+
+  test("Delete button appears and calls delete callback", async () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/rosterstudents")
+      .reply(200, { message: "Roster Student deleted" });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RosterStudentsTable
+            rosterStudents={rosterStudentsFixtures.threeRosterStudents}
+            showButtons={true}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const deleteButton = screen.getByTestId(
+      "RosterStudentsTable-cell-row-0-col-Delete-button",
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveTextContent("Delete");
+    expect(deleteButton).toHaveAttribute("class", "btn btn-danger");
+
+    
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+  });
+});

--- a/frontend/src/tests/components/RosterStudents/RosterStudentsTable.test.js
+++ b/frontend/src/tests/components/RosterStudents/RosterStudentsTable.test.js
@@ -140,7 +140,6 @@ describe("RosterStudentsTable tests", () => {
   });
 
   test("Delete button appears and calls delete callback", async () => {
-
     const axiosMock = new AxiosMockAdapter(axios);
     axiosMock
       .onDelete("/api/rosterstudents")
@@ -164,7 +163,6 @@ describe("RosterStudentsTable tests", () => {
     expect(deleteButton).toHaveTextContent("Delete");
     expect(deleteButton).toHaveAttribute("class", "btn btn-danger");
 
-    
     fireEvent.click(deleteButton);
 
     await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));

--- a/frontend/src/tests/utils/rosterStudentUtils.test.js
+++ b/frontend/src/tests/utils/rosterStudentUtils.test.js
@@ -1,0 +1,51 @@
+import {
+  onDeleteSuccess,
+  cellToAxiosParamsDelete,
+} from "main/utils/rosterStudentUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+describe("helpRequestUtils", () => {
+  describe("onDeleteSuccess", () => {
+    test("It puts the message on console.log and in a toast", () => {
+      // arrange
+      const restoreConsole = mockConsole();
+
+      // act
+      onDeleteSuccess("abc");
+
+      // assert
+      expect(mockToast).toHaveBeenCalledWith("abc");
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toMatch("abc");
+
+      restoreConsole();
+    });
+  });
+  describe("cellToAxiosParamsDelete", () => {
+    test("It returns the correct params", () => {
+      // arrange
+      const cell = { row: { values: { id: 17 } } };
+
+      // act
+      const result = cellToAxiosParamsDelete(cell);
+
+      // assert
+      expect(result).toEqual({
+        url: "/api/rosterstudents",
+        method: "DELETE",
+        params: { id: 17 },
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes #24 

Merge AFTER #32 (already merged)

This PR adds a table component for Roster Students, along with corresponding tests. The table has not been integrated into the app but can be viewed on Storybook.

Following the pattern in the Courses table, buttons are shown/hidden via a prop passed to the component. When we integrate this component into the app, the page should set the prop based on the current user's admin status.

[Storybook](https://6823eaf05481aef71c91a258-yrwslcufmj.chromatic.com/?path=/story/components-rosterstudents-rosterstudentstable--empty)

Screenshots:

Empty Table
<img width="1086" alt="img1" src="https://github.com/user-attachments/assets/9e11c4a0-2926-4b4c-923c-726e0ae6a2ae" />

Three Roster Students
<img width="1086" alt="img2" src="https://github.com/user-attachments/assets/80595c17-e860-4069-8c99-d25cf0c1ab68" />

Three Roster Students with Edit/Delete buttons
<img width="1086" alt="img3" src="https://github.com/user-attachments/assets/ec923dc0-b8c0-44d3-9a1e-2d31da3c9003" />
