### PR TITLE
aw - RosterStudentsForm

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10646,9 +10646,7 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001718",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+      "version": "1.0.30001651",
       "funding": [
         {
           "type": "opencollective",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10646,7 +10646,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001651",
+      "version": "1.0.30001718",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
       "funding": [
         {
           "type": "opencollective",

--- a/frontend/src/main/components/RosterStudents/RosterStudentsForm.js
+++ b/frontend/src/main/components/RosterStudents/RosterStudentsForm.js
@@ -1,0 +1,117 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+
+function RosterStudentsForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "RosterStudentsForm";
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      {initialContents && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="id">Id</Form.Label>
+          <Form.Control
+            data-testid={testIdPrefix + "-id"}
+            id="id"
+            type="text"
+            {...register("id")}
+            value={initialContents.id}
+            disabled
+          />
+        </Form.Group>
+      )}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="studentId">Student Id</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-studentId"}
+          id="studentId"
+          type="text"
+          isInvalid={Boolean(errors.studentId)}
+          {...register("studentId", {
+            required: "studentId is required.",
+            maxLength: {
+              value: 255,
+              message: "Max length 255 characters",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.studentId?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="firstName">First Name</Form.Label>
+        <Form.Control
+          id="firstName"
+          type="text"
+          isInvalid={Boolean(errors.firstName)}
+          {...register("firstName", {
+            required: "FirstName is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.firstName?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="lastName">Last Name</Form.Label>
+        <Form.Control
+          id="lastName"
+          type="text"
+          isInvalid={Boolean(errors.lastName)}
+          {...register("lastName", {
+            required: "LastName is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.lastName?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="email">Email</Form.Label>
+        <Form.Control
+          id="email"
+          type="text"
+          isInvalid={Boolean(errors.email)}
+          {...register("email", {
+            required: "Email is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.email?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={testIdPrefix + "-cancel"}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default RosterStudentsForm;

--- a/frontend/src/main/components/RosterStudents/RosterStudentsForm.js
+++ b/frontend/src/main/components/RosterStudents/RosterStudentsForm.js
@@ -43,7 +43,7 @@ function RosterStudentsForm({
           type="text"
           isInvalid={Boolean(errors.studentId)}
           {...register("studentId", {
-            required: "studentId is required.",
+            required: "Student Id is required.",
             maxLength: {
               value: 255,
               message: "Max length 255 characters",
@@ -62,7 +62,7 @@ function RosterStudentsForm({
           type="text"
           isInvalid={Boolean(errors.firstName)}
           {...register("firstName", {
-            required: "FirstName is required.",
+            required: "First Name is required.",
           })}
         />
         <Form.Control.Feedback type="invalid">
@@ -77,7 +77,7 @@ function RosterStudentsForm({
           type="text"
           isInvalid={Boolean(errors.lastName)}
           {...register("lastName", {
-            required: "LastName is required.",
+            required: "Last Name is required.",
           })}
         />
         <Form.Control.Feedback type="invalid">

--- a/frontend/src/main/components/RosterStudents/RosterStudentsForm.js
+++ b/frontend/src/main/components/RosterStudents/RosterStudentsForm.js
@@ -16,6 +16,7 @@ function RosterStudentsForm({
   // Stryker restore all
 
   const navigate = useNavigate();
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
   const testIdPrefix = "RosterStudentsForm";
 
@@ -58,6 +59,7 @@ function RosterStudentsForm({
       <Form.Group className="mb-3">
         <Form.Label htmlFor="firstName">First Name</Form.Label>
         <Form.Control
+          data-testid={testIdPrefix + "-firstName"}
           id="firstName"
           type="text"
           isInvalid={Boolean(errors.firstName)}
@@ -73,6 +75,7 @@ function RosterStudentsForm({
       <Form.Group className="mb-3">
         <Form.Label htmlFor="lastName">Last Name</Form.Label>
         <Form.Control
+          data-testid={testIdPrefix + "-lastName"}
           id="lastName"
           type="text"
           isInvalid={Boolean(errors.lastName)}
@@ -88,12 +91,18 @@ function RosterStudentsForm({
       <Form.Group className="mb-3">
         <Form.Label htmlFor="email">Email</Form.Label>
         <Form.Control
+          data-testid={testIdPrefix + "-email"}
           id="email"
           type="text"
           isInvalid={Boolean(errors.email)}
           {...register("email", {
             required: "Email is required.",
+            pattern: {
+              value: emailRegex,
+              message: "Email is not valid.",
+            },
           })}
+          disabled={initialContents}
         />
         <Form.Control.Feedback type="invalid">
           {errors.email?.message}

--- a/frontend/src/main/components/RosterStudents/RosterStudentsForm.js
+++ b/frontend/src/main/components/RosterStudents/RosterStudentsForm.js
@@ -16,6 +16,8 @@ function RosterStudentsForm({
   // Stryker restore all
 
   const navigate = useNavigate();
+
+  // Stryker disable next-line Regex
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
   const testIdPrefix = "RosterStudentsForm";

--- a/frontend/src/stories/components/RosterStudents/RosterStudentsForm.stories.js
+++ b/frontend/src/stories/components/RosterStudents/RosterStudentsForm.stories.js
@@ -1,0 +1,33 @@
+import React from "react";
+import RosterStudentsForm from "main/components/RosterStudents/RosterStudentsForm";
+import rosterStudentsFixtures from "fixtures/rosterStudentsFixtures";
+
+export default {
+  title: "components/RosterStudents/RosterStudentsForm",
+  component: RosterStudentsForm,
+};
+
+const Template = (args) => {
+  return <RosterStudentsForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: rosterStudentsFixtures.threeRosterStudents[0],
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/tests/components/RosterStudents/RosterStudentsForm.test.js
+++ b/frontend/src/tests/components/RosterStudents/RosterStudentsForm.test.js
@@ -88,9 +88,13 @@ describe("RosterStudentsForm tests", () => {
     fireEvent.click(submitButton);
 
     await screen.findByTestId(`${testId}-studentId`);
+    await screen.findByText(/Student Id is required./);
     expect(screen.getByTestId(`${testId}-firstName`)).toBeInTheDocument();
+    expect(screen.getByText(/First Name is required/)).toBeInTheDocument();
     expect(screen.getByTestId(`${testId}-lastName`)).toBeInTheDocument();
+    expect(screen.getByText(/Last Name is required/)).toBeInTheDocument();
     expect(screen.getByTestId(`${testId}-email`)).toBeInTheDocument();
+    expect(screen.getByText(/Email is required/)).toBeInTheDocument();
 
     const studentIdInput = screen.getByTestId(`${testId}-studentId`);
     fireEvent.change(studentIdInput, { target: { value: "a".repeat(256) } });

--- a/frontend/src/tests/components/RosterStudents/RosterStudentsForm.test.js
+++ b/frontend/src/tests/components/RosterStudents/RosterStudentsForm.test.js
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
+import RosterStudentsForm from "main/components/RosterStudents/RosterStudentsForm";
+import rosterStudentsFixtures from "fixtures/rosterStudentsFixtures";
+
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe("RosterStudentsForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = ["Student Id", "First Name", "Last Name", "Email"];
+  const testId = "RosterStudentsForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RosterStudentsForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RosterStudentsForm
+            initialContents={rosterStudentsFixtures.threeRosterStudents[0]}
+          />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+    expect(screen.getByText(`Id`)).toBeInTheDocument();
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RosterStudentsForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RosterStudentsForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByTestId(`${testId}-submit`);
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Student Id is required/);
+    expect(screen.getByText(/First Name is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Last Name is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Email is required/)).toBeInTheDocument();
+
+    const studentIdInput = screen.getByTestId(`${testId}-studentId`);
+    fireEvent.change(studentIdInput, { target: { value: "a".repeat(256) } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Max length 255 characters/)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/tests/components/RosterStudents/RosterStudentsForm.test.js
+++ b/frontend/src/tests/components/RosterStudents/RosterStudentsForm.test.js
@@ -87,10 +87,10 @@ describe("RosterStudentsForm tests", () => {
     const submitButton = screen.getByTestId(`${testId}-submit`);
     fireEvent.click(submitButton);
 
-    await screen.findByText(/Student Id is required/);
-    expect(screen.getByText(/First Name is required/)).toBeInTheDocument();
-    expect(screen.getByText(/Last Name is required/)).toBeInTheDocument();
-    expect(screen.getByText(/Email is required/)).toBeInTheDocument();
+    await screen.findByTestId(`${testId}-studentId`);
+    expect(screen.getByTestId(`${testId}-firstName`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-lastName`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-email`)).toBeInTheDocument();
 
     const studentIdInput = screen.getByTestId(`${testId}-studentId`);
     fireEvent.change(studentIdInput, { target: { value: "a".repeat(256) } });
@@ -98,6 +98,14 @@ describe("RosterStudentsForm tests", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/Max length 255 characters/)).toBeInTheDocument();
+    });
+
+    const emailInput = screen.getByTestId(`${testId}-email`);
+    fireEvent.change(emailInput, { target: { value: "invalid email" } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Email is not valid/)).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Closes #21 

Merge AFTER #31

This PR adds a form component to Roster Students. It does not integrate the form into the app.
The form component is in the context of being called from a course, which will be implemented later. Therefore, we only allow creation/update to the rosterStudent's studentId, firstName, lastName, and email. The other fields will be populated by the course or by the student's information. 

Note: I handled the update endpoint for RosterStudents, and the issue description mentioned how emails should not be updated, and so the update endpoint for RosterStudents will only actually update the studentId, firstName, and lastName. This form disables the email section on the update page. This can be removed by removing the line of code disabling email when the update endpoint supports email update.

To test this form component, use the StoryBook link: https://6823eaf05481aef71c91a258-lqpzmbzxdp.chromatic.com/?path=/story/components-rosterstudents-rosterstudentsform--create

Create Page:
<img width="1306" alt="image" src="https://github.com/user-attachments/assets/d29b4942-24e6-4ef4-b87b-a5bc3cc27170" />

Update Page: 
<img width="1320" alt="image" src="https://github.com/user-attachments/assets/32de49af-6fe6-48fa-81cf-2d5115e35551" />