### PR TITLE
simony05 - Added table for CourseStaff with Post and Get methods

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
@@ -53,10 +53,6 @@ public class CourseStaffController extends ApiController {
     @Autowired
     private OrganizationMemberService organizationMemberService;
 
-    public enum InsertStatus {
-        INSERTED, UPDATED
-    };
-
     @Autowired
     private CourseStaffRepository courseStaffRepository;
 

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
@@ -1,0 +1,118 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import edu.ucsb.cs156.frontiers.entities.Job;
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
+import edu.ucsb.cs156.frontiers.jobs.UpdateOrgMembershipJob;
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import edu.ucsb.cs156.frontiers.services.*;
+import edu.ucsb.cs156.frontiers.services.jobs.JobService;
+import org.apache.coyote.BadRequestException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.CourseStaff;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import edu.ucsb.cs156.frontiers.enums.RosterStatus;
+import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
+import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.repositories.CourseStaffRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvException;
+
+@Tag(name = "CourseStaff")
+@RequestMapping("/api/coursestaff")
+@RestController
+@Slf4j
+public class CourseStaffController extends ApiController {
+
+    @Autowired
+    private JobService jobService;
+    @Autowired
+    private OrganizationMemberService organizationMemberService;
+
+    public enum InsertStatus {
+        INSERTED, UPDATED
+    };
+
+    @Autowired
+    private CourseStaffRepository courseStaffRepository;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @Autowired
+    private UpdateUserService updateUserService;
+
+    @Autowired
+    private CurrentUserService currentUserService;
+
+    /**
+     * This method creates a new CourseStaff.
+     * 
+     * 
+     * @return the created CourseStaff
+     */
+
+    @Operation(summary = "Create a new course staff")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public CourseStaff postCourseStaff(
+            @Parameter(name = "firstName") @RequestParam String firstName,
+            @Parameter(name = "lastName") @RequestParam String lastName,
+            @Parameter(name = "email") @RequestParam String email,
+            @Parameter(name = "courseId") @RequestParam Long courseId) throws EntityNotFoundException {
+
+        // Get Course or else throw an error
+
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
+
+        CourseStaff courseStaff = CourseStaff.builder()
+                .firstName(firstName)
+                .lastName(lastName)
+                .email(email)
+                .course(course)
+                .build();
+        CourseStaff savedCourseStaff = courseStaffRepository.save(courseStaff);
+
+        return savedCourseStaff;
+    }
+
+    /**
+     * This method returns a list of course staff for a given course.
+     * 
+     * @return a list of all courses.
+     */
+    @Operation(summary = "List all course staff for a course")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/course")
+    public Iterable<CourseStaff> courseStaffForCourse(
+            @Parameter(name = "courseId") @RequestParam Long courseId) throws EntityNotFoundException {
+        courseRepository.findById(courseId).orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
+        Iterable<CourseStaff> courseStaffs = courseStaffRepository.findByCourseId(courseId);
+        return courseStaffs;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/entities/CourseStaff.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/entities/CourseStaff.java
@@ -19,6 +19,10 @@ public class CourseStaff {
     @ToString.Exclude
     private User user;
 
+    private String firstName;
+    private String lastName;
+    private String email;
+
     @ManyToOne
     @JoinColumn(name = "course_id")
     @ToString.Exclude

--- a/src/main/java/edu/ucsb/cs156/frontiers/repositories/CourseStaffRepository.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/repositories/CourseStaffRepository.java
@@ -1,9 +1,17 @@
 package edu.ucsb.cs156.frontiers.repositories;
 
+import java.util.Optional;
+
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import edu.ucsb.cs156.frontiers.entities.CourseStaff;
 
+import java.util.List;
+
 public interface CourseStaffRepository extends JpaRepository<CourseStaff,Long>
 {
+    List<CourseStaff> findAllByEmail(String email);
+    public Iterable<CourseStaff> findByCourseId(Long courseId);
 }

--- a/src/main/resources/db/migration/changes/008-CourseStaff-add-staff-fields.json
+++ b/src/main/resources/db/migration/changes/008-CourseStaff-add-staff-fields.json
@@ -1,0 +1,50 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "008-CourseStaff-add-staff-fields",
+        "author": "simony05",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": {
+              "columnExists": {
+                "tableName": "COURSE_STAFF",
+                "columnName": "FIRST_NAME"
+              }
+            }
+          }
+        ],
+        "changes": [
+          {
+            "addColumn": {
+              "tableName": "COURSE_STAFF",
+              "columns": [
+                {
+                  "column": {
+                    "name": "FIRST_NAME",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "LAST_NAME",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "EMAIL",
+                    "type": "VARCHAR(255)"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffControllerTests.java
@@ -1,0 +1,216 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.frontiers.entities.Job;
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.jobs.UpdateOrgMembershipJob;
+import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
+import edu.ucsb.cs156.frontiers.services.jobs.JobService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.frontiers.ControllerTestCase;
+import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.CourseStaff;
+import edu.ucsb.cs156.frontiers.enums.OrgStatus;
+import edu.ucsb.cs156.frontiers.enums.RosterStatus;
+import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
+import edu.ucsb.cs156.frontiers.repositories.CourseStaffRepository;
+import edu.ucsb.cs156.frontiers.services.CurrentUserService;
+import edu.ucsb.cs156.frontiers.services.UpdateUserService;
+import lombok.extern.slf4j.Slf4j;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+import org.springframework.http.MediaType;
+
+@Slf4j
+@WebMvcTest(controllers = CourseStaffController.class)
+@AutoConfigureDataJpa
+public class CourseStaffControllerTests extends ControllerTestCase {
+
+        @MockitoBean
+        private CourseRepository courseRepository;
+
+        @MockitoBean
+        private CourseStaffRepository courseStaffRepository;
+
+        @Autowired
+        private CurrentUserService currentUserService;
+
+        @MockitoBean
+        private UpdateUserService updateUserService;
+
+        @MockitoBean
+        private OrganizationMemberService organizationMemberService;
+
+        @MockitoBean
+        private JobService service;
+
+        @Autowired
+        private ObjectMapper objectMapper;
+
+        Course course1 = Course.builder()
+                        .id(1L)
+                        .courseName("CS156")
+                        .orgName("ucsb-cs156-s25")
+                        .term("S25")
+                        .school("UCSB")
+                        .build();
+
+        CourseStaff cs1 = CourseStaff.builder()
+                        .firstName("Chris")
+                        .lastName("Gaucho")
+                        .email("cgaucho@example.org")
+                        .course(course1)
+                        .build();
+
+        CourseStaff cs2 = CourseStaff.builder()
+                        .id(2L)
+                        .firstName("Lauren")
+                        .lastName("Del Playa")
+                        .email("ldelplaya@ucsb.edu")
+                        .course(course1)
+                        .build();
+
+        /**
+         * Test the POST endpoint
+         */
+        @Test
+        @WithMockUser(roles = { "ADMIN" })
+        public void testPostCourseStaff() throws Exception {
+
+                when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course1));
+                when(courseStaffRepository.save(any(CourseStaff.class))).thenReturn(cs1);
+
+                // act
+
+                MvcResult response = mockMvc.perform(post("/api/coursestaff/post")
+                                .with(csrf())
+                                .param("firstName", "Chris")
+                                .param("lastName", "Gaucho")
+                                .param("email", "cgaucho@example.org")
+                                .param("courseId", "1"))
+                                .andExpect(status().isOk())
+                                .andReturn();
+
+                // assert
+
+                verify(courseRepository, times(1)).findById(eq(1L));
+                verify(courseStaffRepository, times(1)).save(eq(cs1));
+
+                String responseString = response.getResponse().getContentAsString();
+                String expectedJson = mapper.writeValueAsString(cs1);
+                assertEquals(expectedJson, responseString);
+
+        }
+
+        /**
+         * Test that you cannot post a single roster student for a course that does not
+         * exist
+         * 
+         * @throws Exception
+         */
+
+        @Test
+        @WithMockUser(roles = { "ADMIN" })
+        public void test_AdminCannotPostCourseStaffForCourseThatDoesNotExist() throws Exception {
+                when(courseRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+                // act
+
+                MvcResult response = mockMvc.perform(post("/api/coursestaff/post")
+                                .with(csrf())
+                                .param("firstName", "Chris")
+                                .param("lastName", "Gaucho")
+                                .param("email", "cgaucho@example.org")
+                                .param("courseId", "1"))
+                                .andExpect(status().isNotFound())
+                                .andReturn();
+
+                // assert
+
+                String responseString = response.getResponse().getContentAsString();
+                Map<String, String> expectedMap = Map.of(
+                                "type", "EntityNotFoundException",
+                                "message", "Course with id 1 not found");
+                String expectedJson = mapper.writeValueAsString(expectedMap);
+                assertEquals(expectedJson, responseString);
+
+        }
+
+        /**
+         * Test the GET endpoint
+         */
+
+        @Test
+        @WithMockUser(roles = { "ADMIN" })
+        public void testCourseStaffByCourse() throws Exception {
+
+                // arrange
+
+                when(courseRepository.findById(eq(1L))).thenReturn(Optional.of(course1));
+                when(courseStaffRepository.findByCourseId(eq(1L))).thenReturn(java.util.List.of(cs1, cs2));
+
+                // act
+
+                MvcResult response = mockMvc.perform(get("/api/coursestaff/course")
+                                .param("courseId", "1"))
+                                .andExpect(status().isOk())
+                                .andReturn();
+
+                // assert
+
+                String responseString = response.getResponse().getContentAsString();
+                String expectedJson = mapper.writeValueAsString(java.util.List.of(cs1, cs2));
+                assertEquals(expectedJson, responseString);
+        }
+
+        /** Test whether admin can get course staff for a non existing course */
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_get_course_staff_for_a_non_existing_course() throws Exception {
+
+                // arrange
+
+                when(courseRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+                // act
+
+                MvcResult response = mockMvc.perform(get("/api/coursestaff/course")
+                                .param("courseId", "1"))
+                                .andExpect(status().isNotFound())
+                                .andReturn();
+
+                // assert
+
+                verify(courseRepository, atLeastOnce()).findById(eq(1L));
+                String responseString = response.getResponse().getContentAsString();
+                Map<String, String> expectedMap = Map.of(
+                                "type", "EntityNotFoundException",
+                                "message", "Course with id 1 not found");
+                String expectedJson = mapper.writeValueAsString(expectedMap);
+                assertEquals(expectedJson, responseString);
+
+        }
+}


### PR DESCRIPTION
Closes #38 
This PR makes Repository, Controller ,and Controller tests for CourseStaff. 

I need this in order to work on Issue #9, which checks the courses that the current user is a staff in. 

This is the response body for Post for adding a staff to a course
<img width="272" alt="Screenshot 2025-05-21 at 6 00 16 PM" src="https://github.com/user-attachments/assets/d345c515-619f-44bc-aa26-5c3bc4799adc" />

This is the response body for Get all staff in Course id with 1
<img width="350" alt="Screenshot 2025-05-21 at 6 01 13 PM" src="https://github.com/user-attachments/assets/54c9300d-96b8-4250-a1dd-deb623f0baa4" />

Dokku: https://frontiers-simony05-dev.dokku-12.cs.ucsb.edu/

To test: Both methods are in the end point /api/coursestaff/
1. Use Post to add a staff to a course
2. Use Get with course id to get staff in that course
