### PR TITLE
simony05 - added controller for students to see courses where they  are staff in

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CourseStaffController.java
@@ -100,7 +100,7 @@ public class CourseStaffController extends ApiController {
     /**
      * This method returns a list of course staff for a given course.
      * 
-     * @return a list of all courses.
+     * @return a list of all course staff.
      */
     @Operation(summary = "List all course staff for a course")
     @PreAuthorize("hasRole('ROLE_ADMIN')")

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 
 import edu.ucsb.cs156.frontiers.entities.User;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.entities.CourseStaff;
 import edu.ucsb.cs156.frontiers.entities.Course;
 import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
 import edu.ucsb.cs156.frontiers.errors.InvalidInstallationTypeException;
@@ -35,6 +36,7 @@ import edu.ucsb.cs156.frontiers.services.OrganizationLinkerService;
 
 import edu.ucsb.cs156.frontiers.repositories.UserRepository;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import edu.ucsb.cs156.frontiers.repositories.CourseStaffRepository;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -55,6 +57,9 @@ public class CoursesController extends ApiController {
 
     @Autowired
     private RosterStudentRepository rosterStudentRepository;
+
+    @Autowired
+    private CourseStaffRepository courseStaffRepository;
 
     @Autowired private OrganizationLinkerService linkerService;
 
@@ -190,6 +195,32 @@ public class CoursesController extends ApiController {
         List<Long> courseIds = new ArrayList<>();
         for (RosterStudent roster : rosters) {
             courseIds.add(roster.getCourse().getId());
+        }
+
+        Iterable<Course> courses = courseRepository.findAllById(courseIds);
+        return courses;
+    }
+
+    /**
+     * student see what courses they appear as staff in
+     * 
+     * @param studentId the id of the student making request
+     * @return a list of all courses student is staff in
+     */
+    @Operation(summary= "Student see what courses they appear as staff in")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/staffCourses") 
+    public Iterable<Course> staffCourses() {
+        CurrentUser currentUser = getCurrentUser();
+        User user = currentUser.getUser();
+
+        String email = user.getEmail();
+
+        Iterable<CourseStaff> staffs = courseStaffRepository.findAllByEmail(email);
+        
+        List<Long> courseIds = new ArrayList<>();
+        for (CourseStaff staff : staffs) {
+            courseIds.add(staff.getCourse().getId());
         }
 
         Iterable<Course> courses = courseRepository.findAllById(courseIds);


### PR DESCRIPTION
Closes #9 
This PR creates a Courses controller that gets the current user's email and returns all courses they are part of

IMPORTANT: this PR builds off of https://github.com/ucsb-cs156-s25/proj-frontiers-s25-12/pull/42
PR42 creates CourseStaff table and methods, which are used to check in this controller to find the courses associated with entries in CourseStaff table with the current user's email.

<img width="308" alt="Screenshot 2025-05-21 at 7 45 07 PM" src="https://github.com/user-attachments/assets/9348b3e8-6f0e-4294-9274-c8bf37bfe15b" />

Dokku: https://frontiers-simony05-dev.dokku-12.cs.ucsb.edu/

How to test:

1. Add yourself as staff in some course using the endpoint api/coursestaff
Use the endpoint /api/courses/staffCourse to Get the Course entries where you are a CourseStaff of, which should return any Courses that you added yourself to in CourseStaff
