### PR TITLE
hk - FEATURE - ADMIN_EMAILS are added to the admins table at startup. #6

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/startup/FrontiersApplicationRunner.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/startup/FrontiersApplicationRunner.java
@@ -1,0 +1,21 @@
+package edu.ucsb.cs156.frontiers.startup;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class FrontiersApplicationRunner implements ApplicationRunner {
+
+    @Autowired
+    private FrontiersStartup frontiersStartup;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        log.info("FrontiersApplicationRunner.run called");
+        frontiersStartup.alwaysRunOnStartup();
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/startup/FrontiersStartup.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/startup/FrontiersStartup.java
@@ -1,0 +1,36 @@
+package edu.ucsb.cs156.frontiers.startup;
+
+import edu.ucsb.cs156.frontiers.entities.Admin;
+import edu.ucsb.cs156.frontiers.repositories.AdminRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Slf4j
+@Component
+public class FrontiersStartup {
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    @Value("${admin.emails:}")
+    private String adminEmails;
+
+    public void alwaysRunOnStartup() {
+        log.info("FrontiersStartup.alwaysRunOnStartup called");
+
+        String[] emails = adminEmails.split(",");
+        for (String email : emails) {
+            email = email.trim();
+            if (!email.isEmpty()) {
+                if (adminRepository.findById(email).isEmpty()) {
+                    adminRepository.save(Admin.builder().email(email).build());
+                    log.info("Added admin: " + email);
+                } else {
+                    log.info("Admin already exists: " + email);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/startup/FrontiersApplicationRunnerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/startup/FrontiersApplicationRunnerTests.java
@@ -1,0 +1,27 @@
+package edu.ucsb.cs156.frontiers.startup;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.Mockito.*;
+
+class FrontiersApplicationRunnerTests {
+
+    @Test
+    void testRunCallsStartup() throws Exception {
+        // mock dependencies
+        FrontiersStartup mockStartup = mock(FrontiersStartup.class);
+        ApplicationArguments mockArgs = mock(ApplicationArguments.class);
+
+        // instance under test
+        FrontiersApplicationRunner runner = new FrontiersApplicationRunner();
+        ReflectionTestUtils.setField(runner, "frontiersStartup", mockStartup);
+
+        // act
+        runner.run(mockArgs);
+
+        // assert
+        verify(mockStartup, times(1)).alwaysRunOnStartup();
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/startup/FrontiersStartupTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/startup/FrontiersStartupTests.java
@@ -1,0 +1,70 @@
+package edu.ucsb.cs156.frontiers.startup;
+
+import edu.ucsb.cs156.frontiers.entities.Admin;
+import edu.ucsb.cs156.frontiers.repositories.AdminRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+        "admin.emails=test1@ucsb.edu,test2@ucsb.edu"
+})
+class FrontiersStartupTests {
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    @Autowired
+    private FrontiersStartup frontiersStartup;   // real bean
+
+    @BeforeEach
+    void clearRepo() {
+        adminRepository.deleteAll();
+    }
+
+    /** happy‑path: both emails from ADMIN_EMAILS inserted */
+    @Test
+    void testAdminsInsertedOnStartup() {
+        frontiersStartup.alwaysRunOnStartup();
+        assertThat(adminRepository.findById("test1@ucsb.edu")).isPresent();
+        assertThat(adminRepository.findById("test2@ucsb.edu")).isPresent();
+    }
+
+    /** branch: entry already exists, so no duplicate row */
+    @Test
+    void testSkipsExistingAdmin() {
+        adminRepository.save(Admin.builder().email("test1@ucsb.edu").build());
+        frontiersStartup.alwaysRunOnStartup();
+        assertThat(adminRepository.findAll())
+                .filteredOn(a -> a.getEmail().equals("test1@ucsb.edu"))
+                .hasSize(1);
+    }
+
+    /** trims surrounding whitespace */
+    @Test
+    void testTrimsWhitespace() {
+        FrontiersStartup trimmed = new FrontiersStartup();
+        ReflectionTestUtils.setField(trimmed, "adminRepository", adminRepository);
+        ReflectionTestUtils.setField(trimmed, "adminEmails", "  spaced@ucsb.edu  ");
+
+        trimmed.alwaysRunOnStartup();
+        assertThat(adminRepository.findById("spaced@ucsb.edu")).isPresent();
+    }
+
+    /** handles empty / blank entries gracefully */
+    @Test
+    void testSkipsEmptyEntries() {
+        FrontiersStartup blank = new FrontiersStartup();
+        ReflectionTestUtils.setField(blank, "adminRepository", adminRepository);
+        ReflectionTestUtils.setField(blank, "adminEmails", ", , ,");
+
+        blank.alwaysRunOnStartup();
+        assertThat(adminRepository.findAll()).isEmpty();
+    }
+}


### PR DESCRIPTION
Closes #6

Merge after #39 

This PR adds startup code to `proj-frontiers` that inserts all emails listed in the `ADMIN_EMAILS` environment variable into the `admins` table at application startup.

Personal deployment: https://frontiers-dev-hungkhuu04.dokku-12.cs.ucsb.edu/

Verification:
Running a SQL query directly on Dokku’s Postgres instance right after redeployment:
<img width="784" alt="Screenshot 2025-05-22 at 1 31 32 AM" src="https://github.com/user-attachments/assets/6c4d5d85-2791-4fe0-a692-68902be9e753" />
